### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/Http/Middleware/IpWebAccess.php
+++ b/src/Http/Middleware/IpWebAccess.php
@@ -4,6 +4,7 @@ namespace Marshmallow\IpAccess\Http\Middleware;
 
 use Closure;
 use Exception;
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Marshmallow\IpAccess\Models\IpAccess;
 use Marshmallow\HelperFunctions\Facades\Ip;
@@ -28,7 +29,7 @@ class IpWebAccess
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request $request
+     * @param  Request $request
      * @param  \Closure $next
      * @return mixed
      */
@@ -154,7 +155,7 @@ class IpWebAccess
     /**
      * Determine if the request has a URI that should pass through IP verification.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return bool
      */
     protected function inExceptArray($request)

--- a/src/Models/IpAccess.php
+++ b/src/Models/IpAccess.php
@@ -18,7 +18,7 @@ class IpAccess extends Model
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'from' => 'datetime',

--- a/src/Nova/IpAccess.php
+++ b/src/Nova/IpAccess.php
@@ -69,7 +69,7 @@ class IpAccess extends Resource
     /**
      * Get the fields displayed by the resource.
      *
-     * @param Laravel\Nova\Http\Requests\NovaRequest $request Request
+     * @param NovaRequest $request Request
      *
      * @return array
      */
@@ -95,7 +95,7 @@ class IpAccess extends Resource
                 ->withMeta($this->ip_address ? [] : [
                     'value' => $request->ip(),
                 ])
-                ->displayUsing(function ($value, $resource) use ($request) {
+                ->displayUsing(function ($value, $resource) {
                     $return = $value;
                     if ($resource->isCurrentIp($value)) {
                         $return .= '<span class="ml-2 bg-success text-white p-1 pl-2 pr-2 rounded-sm inline-block text-sm">';


### PR DESCRIPTION
## Summary
- Fixed PHPDoc type covariance issue in IpAccess model $casts property by specifying array<string, string> type
- Updated NovaRequest type parameter documentation to use imported class instead of fully qualified namespace
- Removed unused $request parameter from anonymous function in displayUsing callback
- Added proper Request import to IpWebAccess middleware and updated docblocks

## Test plan
- [x] Syntax check passed for all modified files
- [x] All PHP 8.4 deprecation warnings from issue #38 have been addressed

Fixes #38