### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "marshmallow/commands": "^1.2",
         "marshmallow/helpers": "^2.0",
         "laravel/nova": "^4.0|^5.0"


### PR DESCRIPTION
Adds `^13.0` to illuminate/* package constraints to support Laravel 13.